### PR TITLE
feat: [CGC-14] Create Annotations for Months in Week Chart

### DIFF
--- a/i18n/en.pot
+++ b/i18n/en.pot
@@ -5,14 +5,17 @@ msgstr ""
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1)\n"
-"POT-Creation-Date: 2024-02-27T11:30:24.370Z\n"
-"PO-Revision-Date: 2024-02-27T11:30:24.370Z\n"
+"POT-Creation-Date: 2024-03-04T09:50:08.881Z\n"
+"PO-Revision-Date: 2024-03-04T09:50:08.881Z\n"
 
 msgid "Year"
 msgstr "Year"
 
 msgid "Years"
 msgstr "Years"
+
+msgid "Month"
+msgstr "Month"
 
 msgid "Months"
 msgstr "Months"

--- a/src/Components/GrowthChart/GrowthChartOptions/GrowthChartAnnotations.tsx
+++ b/src/Components/GrowthChart/GrowthChartOptions/GrowthChartAnnotations.tsx
@@ -1,18 +1,44 @@
 import i18n from '@dhis2/d2-i18n';
+import { timeUnitCodes } from '../../../types/chartDataTypes';
 
+interface TimeUnitData {
+    singular: string;
+    plural: string;
+    divisor: number;
+}
 export interface AnnotationLabelType {
     display: boolean;
-    content?: () => string;
-    position?: 'top' | 'bottom' | 'center' | 'start' | 'end';
+    content?: (value: number) => string;
+    position?: 'end';
     yAdjust?: number;
 }
 
+const timeUnitData: { [key: string]: TimeUnitData } = {
+    [timeUnitCodes.months]: {
+        singular: i18n.t('Year'),
+        plural: i18n.t('Years'),
+        divisor: 12,
+    },
+    [timeUnitCodes.weeks]: {
+        singular: i18n.t('Month'),
+        plural: i18n.t('Months'),
+        divisor: 4,
+    },
+};
+
+const contentText = (value: number, timeUnit: string) => {
+    const { singular, plural } = timeUnitData[timeUnit];
+    return `${value} ${value === 1 ? singular : plural}`;
+};
+
 export const GrowthChartAnnotations = (xAxisValues: number[], timeUnit: string) => {
-    if (timeUnit === 'Months') {
+    const timeUnitConfig = timeUnitData[timeUnit];
+    if (timeUnitConfig) {
         const firstXValue = xAxisValues[0];
+        const { divisor } = timeUnitConfig;
 
         const annotations = xAxisValues
-            .filter((label) => label % 12 === 0)
+            .filter((label) => label % divisor === 0)
             .map((label) => ({
                 display: true,
                 type: 'line',
@@ -22,17 +48,20 @@ export const GrowthChartAnnotations = (xAxisValues: number[], timeUnit: string) 
                 label: {
                     display: true,
                     content: () => {
-                        const value = label / 12;
-                        return `${value} ${value === 1 ? i18n.t('Year') : i18n.t('Years')}`;
+                        const value = label / divisor;
+                        return contentText(value, timeUnit);
                     },
                     position: 'end',
                     yAdjust: 10,
+                    font: [{ size: 13, weight: 'normal' }],
+                    color: 'rgba(75, 75, 75)',
+                    backgroundColor: 'rgba(237, 237, 237)',
                 },
-
             }));
-        annotations.pop();
+        if ((xAxisValues.length - 1) % 12 === 0) {
+            annotations.pop();
+        }
         annotations.shift();
-
         return annotations;
     }
     return [];

--- a/src/Components/GrowthChart/GrowthChartOptions/GrowthChartAnnotations.tsx
+++ b/src/Components/GrowthChart/GrowthChartOptions/GrowthChartAnnotations.tsx
@@ -9,7 +9,7 @@ interface TimeUnitData {
 export interface AnnotationLabelType {
     display: boolean;
     content?: (value: number) => string;
-    position?: 'end';
+    position?: 'top' | 'bottom' | 'center' | 'start' | 'end';
     yAdjust?: number;
 }
 


### PR DESCRIPTION
 - Created an interface TimeUnitData to represent unit data, including **singular**, **plural**, and **divisor**.
- Updated the `GrowthChartAnnotations function` to utilize the unit data based on the given **timeUnit**.
- Used the divisor from timeUnitData to calculate the value for **annotations**.
- Added **font**, **color**, and **backgroundColor** properties to annotations to define their appearance.
- Adjusted the condition for removing the last annotation based on the length of **xAxisValues**.